### PR TITLE
更新README 和gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.bak
 *.[568vq]
 [568vq].out
+bin/*

--- a/README
+++ b/README
@@ -97,7 +97,7 @@ Github:  https://github.com/shibingli/webconsole
 一、部署
 1、将程序解压或下载至任一目录，运行 "build.sh" 编译可执行文件
 2、然后运行 "bin" 文件夹下的 "apibox" 文件即可。如:"./apibox start/stop"
-3、配置文件在 "conf" 文件夹下，核心配置文件为 "conf.json"
+3、配置文件在 "conf" 文件夹下，核心配置文件为 "conf.json"，部署的时候需要添加跨域白名单来支持其他机器的访问
 4、后台运行可以配置 "conf" 文件夹下的 "conf.json" 文件,将 "daemon" 项配置为 "true" 
 5、运行时日志文件存放在 "log" 文件夹下，以当天时期命名
 6、也可以配置程序以 Nginx 的 fcgi 模式运行,以 Nginx 做为访问入口


### PR DESCRIPTION
部署的时候需要添加跨域白名单，不然会报403
另外更新了一下gitignore，忽略bin下生成的二进制文件