### PR TITLE
Update console.go

### DIFF
--- a/src/apibox.club/website/console.go
+++ b/src/apibox.club/website/console.go
@@ -32,6 +32,7 @@ func (s *ssh) Connect() (*ssh, error) {
 	config.SetDefaults()
 	config.User = s.user
 	config.Auth = []gossh.AuthMethod{gossh.Password(s.pwd)}
+	config.HostKeyCallback = gossh.InsecureIgnoreHostKey()
 	client, err := gossh.Dial("tcp", s.addr, config)
 	if nil != err {
 		return nil, err


### PR DESCRIPTION
添加config.HostKeyCallback = gossh.InsecureIgnoreHostKey()，否则通过浏览器无法登录。参考：
https://github.com/pkg/sftp/pull/179/commits/a3ba1138031130c87c46232ae5bbfcf97d51ec45